### PR TITLE
Expose the ed25519 API in libsodium

### DIFF
--- a/c_src/ed25519.c
+++ b/c_src/ed25519.c
@@ -92,20 +92,14 @@ ERL_NIF_TERM
 enacl_crypto_ed25519_scalarmult(ErlNifEnv *env, int argc,
                                 ERL_NIF_TERM const argv[]) {
   ERL_NIF_TERM result;
-  ErlNifBinary secret, basepoint, output;
-  uint8_t bp[crypto_scalarmult_ed25519_BYTES];
+  ErlNifBinary scalar, point, output;
 
-  if ((argc != 2) || (!enif_inspect_binary(env, argv[0], &secret)) ||
-      (!enif_inspect_binary(env, argv[1], &basepoint)) ||
-      (secret.size != crypto_scalarmult_ed25519_BYTES) ||
-      (basepoint.size != crypto_scalarmult_ed25519_BYTES)) {
+  if ((argc != 2) || (!enif_inspect_binary(env, argv[0], &scalar)) ||
+      (!enif_inspect_binary(env, argv[1], &point)) ||
+      (scalar.size != crypto_scalarmult_ed25519_BYTES) ||
+      (point.size != crypto_scalarmult_ed25519_BYTES)) {
     return enif_make_badarg(env);
   }
-
-  memcpy(bp, basepoint.data, crypto_scalarmult_ed25519_BYTES);
-
-  /* Clear the high-bit. Better safe than sorry. */
-  bp[crypto_scalarmult_curve25519_BYTES - 1] &= 0x7f;
 
   do {
     if (!enif_alloc_binary(crypto_scalarmult_curve25519_BYTES, &output)) {
@@ -113,7 +107,7 @@ enacl_crypto_ed25519_scalarmult(ErlNifEnv *env, int argc,
       continue;
     }
 
-    if (crypto_scalarmult_ed25519(output.data, secret.data, bp) != 0) {
+    if (crypto_scalarmult_ed25519(output.data, scalar.data, point.data) != 0) {
       enif_release_binary(&output);
       result = enacl_error_tuple(env, "scalarmult_ed25519_failed");
       continue;
@@ -121,8 +115,6 @@ enacl_crypto_ed25519_scalarmult(ErlNifEnv *env, int argc,
 
     result = enif_make_binary(env, &output);
   } while (0);
-
-  sodium_memzero(bp, crypto_scalarmult_curve25519_BYTES);
 
   return result;
 }
@@ -160,20 +152,14 @@ ERL_NIF_TERM
 enacl_crypto_ed25519_scalarmult_noclamp(ErlNifEnv *env, int argc,
                                         ERL_NIF_TERM const argv[]) {
   ERL_NIF_TERM result;
-  ErlNifBinary secret, basepoint, output;
-  uint8_t bp[crypto_scalarmult_ed25519_BYTES];
+  ErlNifBinary scalar, point, output;
 
-  if ((argc != 2) || (!enif_inspect_binary(env, argv[0], &secret)) ||
-      (!enif_inspect_binary(env, argv[1], &basepoint)) ||
-      (secret.size != crypto_scalarmult_ed25519_BYTES) ||
-      (basepoint.size != crypto_scalarmult_ed25519_BYTES)) {
+  if ((argc != 2) || (!enif_inspect_binary(env, argv[0], &scalar)) ||
+      (!enif_inspect_binary(env, argv[1], &point)) ||
+      (scalar.size != crypto_scalarmult_ed25519_BYTES) ||
+      (point.size != crypto_scalarmult_ed25519_BYTES)) {
     return enif_make_badarg(env);
   }
-
-  memcpy(bp, basepoint.data, crypto_scalarmult_ed25519_BYTES);
-
-  /* Clear the high-bit. Better safe than sorry. */
-  bp[crypto_scalarmult_curve25519_BYTES - 1] &= 0x7f;
 
   do {
     if (!enif_alloc_binary(crypto_scalarmult_curve25519_BYTES, &output)) {
@@ -181,7 +167,7 @@ enacl_crypto_ed25519_scalarmult_noclamp(ErlNifEnv *env, int argc,
       continue;
     }
 
-    if (crypto_scalarmult_ed25519_noclamp(output.data, secret.data, bp) != 0) {
+    if (crypto_scalarmult_ed25519_noclamp(output.data, scalar.data, point.data) != 0) {
       enif_release_binary(&output);
       result = enacl_error_tuple(env, "scalarmult_ed25519_noclamp_failed");
       continue;
@@ -189,8 +175,6 @@ enacl_crypto_ed25519_scalarmult_noclamp(ErlNifEnv *env, int argc,
 
     result = enif_make_binary(env, &output);
   } while (0);
-
-  sodium_memzero(bp, crypto_scalarmult_curve25519_BYTES);
 
   return result;
 }

--- a/c_src/ed25519.c
+++ b/c_src/ed25519.c
@@ -1,0 +1,353 @@
+#include <sodium.h>
+#include <string.h>
+
+#include <erl_nif.h>
+
+#include "enacl.h"
+#include "ed25519.h"
+
+ERL_NIF_TERM
+enacl_crypto_ed25519_is_valid_point(ErlNifEnv *env, int argc,
+                                    ERL_NIF_TERM const argv[]) {
+  ErlNifBinary p;
+
+  if ((argc != 1) ||
+      (!enif_inspect_binary(env, argv[0], &p)) ||
+      (p.size != crypto_core_ed25519_BYTES)) {
+    return enif_make_badarg(env);
+  }
+
+  if (1 == crypto_core_ed25519_is_valid_point(p.data)) {
+    return enif_make_atom(env, "true");
+  } else {
+    return enif_make_atom(env, "false");
+  }
+}
+
+ERL_NIF_TERM
+enacl_crypto_ed25519_add(ErlNifEnv *env, int argc,
+                         ERL_NIF_TERM const argv[]) {
+  ERL_NIF_TERM result;
+  ErlNifBinary p, q, output;
+
+  if ((argc != 2) ||
+      (!enif_inspect_binary(env, argv[0], &p)) ||
+      (!enif_inspect_binary(env, argv[1], &q)) ||
+      (p.size != crypto_core_ed25519_BYTES) ||
+      (q.size != crypto_core_ed25519_BYTES)) {
+    return enif_make_badarg(env);
+  }
+
+  do {
+    if (!enif_alloc_binary(crypto_core_ed25519_BYTES, &output)) {
+      result = enacl_internal_error(env);
+      continue;
+    }
+
+    if (crypto_core_ed25519_add(output.data, p.data, q.data) != 0) {
+      enif_release_binary(&output);
+      result = enacl_error_tuple(env, "ed25519_add_failed");
+      continue;
+    }
+
+    result = enif_make_binary(env, &output);
+  } while (0);
+
+  return result;
+}
+
+ERL_NIF_TERM
+enacl_crypto_ed25519_sub(ErlNifEnv *env, int argc,
+                         ERL_NIF_TERM const argv[]) {
+  ERL_NIF_TERM result;
+  ErlNifBinary p, q, output;
+
+  if ((argc != 2) ||
+      (!enif_inspect_binary(env, argv[0], &p)) ||
+      (!enif_inspect_binary(env, argv[1], &q)) ||
+      (p.size != crypto_core_ed25519_BYTES) ||
+      (q.size != crypto_core_ed25519_BYTES)) {
+    return enif_make_badarg(env);
+  }
+
+  do {
+    if (!enif_alloc_binary(crypto_core_ed25519_BYTES, &output)) {
+      result = enacl_internal_error(env);
+      continue;
+    }
+
+    if (crypto_core_ed25519_sub(output.data, p.data, q.data) != 0) {
+      enif_release_binary(&output);
+      result = enacl_error_tuple(env, "ed25519_sub_failed");
+      continue;
+    }
+
+    result = enif_make_binary(env, &output);
+  } while (0);
+
+  return result;
+}
+
+ERL_NIF_TERM
+enacl_crypto_ed25519_scalarmult(ErlNifEnv *env, int argc,
+                                ERL_NIF_TERM const argv[]) {
+  ERL_NIF_TERM result;
+  ErlNifBinary secret, basepoint, output;
+  uint8_t bp[crypto_scalarmult_ed25519_BYTES];
+
+  if ((argc != 2) || (!enif_inspect_binary(env, argv[0], &secret)) ||
+      (!enif_inspect_binary(env, argv[1], &basepoint)) ||
+      (secret.size != crypto_scalarmult_ed25519_BYTES) ||
+      (basepoint.size != crypto_scalarmult_ed25519_BYTES)) {
+    return enif_make_badarg(env);
+  }
+
+  memcpy(bp, basepoint.data, crypto_scalarmult_ed25519_BYTES);
+
+  /* Clear the high-bit. Better safe than sorry. */
+  bp[crypto_scalarmult_curve25519_BYTES - 1] &= 0x7f;
+
+  do {
+    if (!enif_alloc_binary(crypto_scalarmult_curve25519_BYTES, &output)) {
+      result = enacl_internal_error(env);
+      continue;
+    }
+
+    if (crypto_scalarmult_ed25519(output.data, secret.data, bp) != 0) {
+      enif_release_binary(&output);
+      result = enacl_error_tuple(env, "scalarmult_ed25519_failed");
+      continue;
+    }
+
+    result = enif_make_binary(env, &output);
+  } while (0);
+
+  sodium_memzero(bp, crypto_scalarmult_curve25519_BYTES);
+
+  return result;
+}
+
+ERL_NIF_TERM
+enacl_crypto_ed25519_scalarmult_base(ErlNifEnv *env, int argc,
+                                     ERL_NIF_TERM const argv[]) {
+  ERL_NIF_TERM result;
+  ErlNifBinary secret, output;
+
+  if ((argc != 1) || (!enif_inspect_binary(env, argv[0], &secret)) ||
+      (secret.size != crypto_scalarmult_ed25519_BYTES)) {
+    return enif_make_badarg(env);
+  }
+
+  do {
+    if (!enif_alloc_binary(crypto_scalarmult_ed25519_BYTES, &output)) {
+      result = enacl_internal_error(env);
+      continue;
+    }
+
+    if (crypto_scalarmult_ed25519_base(output.data, secret.data) != 0) {
+      enif_release_binary(&output);
+      result = enacl_error_tuple(env, "scalarmult_ed25519_base_failed");
+      continue;
+    }
+
+    result = enif_make_binary(env, &output);
+  } while (0);
+
+  return result;
+}
+
+ERL_NIF_TERM
+enacl_crypto_ed25519_scalarmult_noclamp(ErlNifEnv *env, int argc,
+                                        ERL_NIF_TERM const argv[]) {
+  ERL_NIF_TERM result;
+  ErlNifBinary secret, basepoint, output;
+  uint8_t bp[crypto_scalarmult_ed25519_BYTES];
+
+  if ((argc != 2) || (!enif_inspect_binary(env, argv[0], &secret)) ||
+      (!enif_inspect_binary(env, argv[1], &basepoint)) ||
+      (secret.size != crypto_scalarmult_ed25519_BYTES) ||
+      (basepoint.size != crypto_scalarmult_ed25519_BYTES)) {
+    return enif_make_badarg(env);
+  }
+
+  memcpy(bp, basepoint.data, crypto_scalarmult_ed25519_BYTES);
+
+  /* Clear the high-bit. Better safe than sorry. */
+  bp[crypto_scalarmult_curve25519_BYTES - 1] &= 0x7f;
+
+  do {
+    if (!enif_alloc_binary(crypto_scalarmult_curve25519_BYTES, &output)) {
+      result = enacl_internal_error(env);
+      continue;
+    }
+
+    if (crypto_scalarmult_ed25519_noclamp(output.data, secret.data, bp) != 0) {
+      enif_release_binary(&output);
+      result = enacl_error_tuple(env, "scalarmult_ed25519_noclamp_failed");
+      continue;
+    }
+
+    result = enif_make_binary(env, &output);
+  } while (0);
+
+  sodium_memzero(bp, crypto_scalarmult_curve25519_BYTES);
+
+  return result;
+}
+
+ERL_NIF_TERM
+enacl_crypto_ed25519_scalarmult_base_noclamp(ErlNifEnv *env, int argc,
+                                             ERL_NIF_TERM const argv[]) {
+  ERL_NIF_TERM result;
+  ErlNifBinary secret, output;
+
+  if ((argc != 1) || (!enif_inspect_binary(env, argv[0], &secret)) ||
+      (secret.size != crypto_scalarmult_ed25519_BYTES)) {
+    return enif_make_badarg(env);
+  }
+
+  do {
+    if (!enif_alloc_binary(crypto_scalarmult_ed25519_BYTES, &output)) {
+      result = enacl_internal_error(env);
+      continue;
+    }
+
+    if (crypto_scalarmult_ed25519_base_noclamp(output.data, secret.data) != 0) {
+      enif_release_binary(&output);
+      result = enacl_error_tuple(env, "scalarmult_ed25519_base_noclamp_failed");
+      continue;
+    }
+
+    result = enif_make_binary(env, &output);
+  } while (0);
+
+  return result;
+}
+
+ERL_NIF_TERM
+enacl_crypto_ed25519_scalar_reduce(ErlNifEnv *env, int argc,
+                                   ERL_NIF_TERM const argv[]) {
+  ERL_NIF_TERM result;
+  ErlNifBinary scalar, output;
+
+  if ((argc != 1) || (!enif_inspect_binary(env, argv[0], &scalar)) ||
+      (scalar.size != crypto_core_ed25519_NONREDUCEDSCALARBYTES)) {
+    return enif_make_badarg(env);
+  }
+
+  do {
+    if (!enif_alloc_binary(crypto_core_ed25519_SCALARBYTES, &output)) {
+      result = enacl_internal_error(env);
+      continue;
+    }
+
+    crypto_core_ed25519_scalar_reduce(output.data, scalar.data);
+    result = enif_make_binary(env, &output);
+  } while (0);
+
+  return result;
+}
+
+ERL_NIF_TERM
+enacl_crypto_ed25519_scalar_negate(ErlNifEnv *env, int argc,
+                                   ERL_NIF_TERM const argv[]) {
+  ERL_NIF_TERM result;
+  ErlNifBinary scalar, output;
+
+  if ((argc != 1) || (!enif_inspect_binary(env, argv[0], &scalar)) ||
+      (scalar.size != crypto_core_ed25519_SCALARBYTES)) {
+    return enif_make_badarg(env);
+  }
+
+  do {
+    if (!enif_alloc_binary(crypto_core_ed25519_SCALARBYTES, &output)) {
+      result = enacl_internal_error(env);
+      continue;
+    }
+
+    crypto_core_ed25519_scalar_negate(output.data, scalar.data);
+    result = enif_make_binary(env, &output);
+  } while (0);
+
+  return result;
+}
+
+ERL_NIF_TERM
+enacl_crypto_ed25519_scalar_add(ErlNifEnv *env, int argc,
+                                ERL_NIF_TERM const argv[]) {
+  ERL_NIF_TERM result;
+  ErlNifBinary x, y, output;
+
+  if ((argc != 2) || (!enif_inspect_binary(env, argv[0], &x)) ||
+      (!enif_inspect_binary(env, argv[1], &y)) ||
+      (x.size != crypto_core_ed25519_SCALARBYTES) ||
+      (y.size != crypto_core_ed25519_SCALARBYTES)) {
+    return enif_make_badarg(env);
+  }
+
+  do {
+    if (!enif_alloc_binary(crypto_core_ed25519_SCALARBYTES, &output)) {
+      result = enacl_internal_error(env);
+      continue;
+    }
+
+    crypto_core_ed25519_scalar_add(output.data, x.data, y.data);
+    result = enif_make_binary(env, &output);
+  } while (0);
+
+  return result;
+}
+
+ERL_NIF_TERM
+enacl_crypto_ed25519_scalar_sub(ErlNifEnv *env, int argc,
+                                ERL_NIF_TERM const argv[]) {
+  ERL_NIF_TERM result;
+  ErlNifBinary x, y, output;
+
+  if ((argc != 2) || (!enif_inspect_binary(env, argv[0], &x)) ||
+      (!enif_inspect_binary(env, argv[1], &y)) ||
+      (x.size != crypto_core_ed25519_SCALARBYTES) ||
+      (y.size != crypto_core_ed25519_SCALARBYTES)) {
+    return enif_make_badarg(env);
+  }
+
+  do {
+    if (!enif_alloc_binary(crypto_core_ed25519_SCALARBYTES, &output)) {
+      result = enacl_internal_error(env);
+      continue;
+    }
+
+    crypto_core_ed25519_scalar_sub(output.data, x.data, y.data);
+    result = enif_make_binary(env, &output);
+  } while (0);
+
+  return result;
+}
+
+ERL_NIF_TERM
+enacl_crypto_ed25519_scalar_mul(ErlNifEnv *env, int argc,
+                                ERL_NIF_TERM const argv[]) {
+  ERL_NIF_TERM result;
+  ErlNifBinary x, y, output;
+
+  if ((argc != 2) || (!enif_inspect_binary(env, argv[0], &x)) ||
+      (!enif_inspect_binary(env, argv[1], &y)) ||
+      (x.size != crypto_core_ed25519_SCALARBYTES) ||
+      (y.size != crypto_core_ed25519_SCALARBYTES)) {
+    return enif_make_badarg(env);
+  }
+
+  do {
+    if (!enif_alloc_binary(crypto_core_ed25519_SCALARBYTES, &output)) {
+      result = enacl_internal_error(env);
+      continue;
+    }
+
+    crypto_core_ed25519_scalar_mul(output.data, x.data, y.data);
+    result = enif_make_binary(env, &output);
+  } while (0);
+
+  return result;
+}
+
+

--- a/c_src/ed25519.h
+++ b/c_src/ed25519.h
@@ -1,0 +1,41 @@
+#ifndef ENACL_ED25519_H
+#define ENACL_ED25519_H
+
+#include <erl_nif.h>
+
+ERL_NIF_TERM enacl_crypto_ed25519_scalarmult(ErlNifEnv *env, int argc,
+                                             ERL_NIF_TERM const argv[]);
+
+ERL_NIF_TERM enacl_crypto_ed25519_scalarmult_base(ErlNifEnv *env, int argc,
+                                                  ERL_NIF_TERM const argv[]);
+
+ERL_NIF_TERM enacl_crypto_ed25519_scalarmult_noclamp(
+        ErlNifEnv *env, int argc, ERL_NIF_TERM const argv[]);
+
+ERL_NIF_TERM enacl_crypto_ed25519_scalarmult_base_noclamp(
+        ErlNifEnv *env, int argc, ERL_NIF_TERM const argv[]);
+
+ERL_NIF_TERM enacl_crypto_ed25519_add(ErlNifEnv *env, int argc,
+                                      ERL_NIF_TERM const argv[]);
+
+ERL_NIF_TERM enacl_crypto_ed25519_sub(ErlNifEnv *env, int argc,
+                                      ERL_NIF_TERM const argv[]);
+
+ERL_NIF_TERM enacl_crypto_ed25519_is_valid_point(ErlNifEnv *env, int argc,
+                                                 ERL_NIF_TERM const argv[]);
+
+ERL_NIF_TERM enacl_crypto_ed25519_scalar_reduce(ErlNifEnv *env, int argc,
+                                                ERL_NIF_TERM const argv[]);
+
+ERL_NIF_TERM enacl_crypto_ed25519_scalar_negate(ErlNifEnv *env, int argc,
+                                                ERL_NIF_TERM const argv[]);
+
+ERL_NIF_TERM enacl_crypto_ed25519_scalar_add(ErlNifEnv *env, int argc,
+                                             ERL_NIF_TERM const argv[]);
+
+ERL_NIF_TERM enacl_crypto_ed25519_scalar_sub(ErlNifEnv *env, int argc,
+                                             ERL_NIF_TERM const argv[]);
+
+ERL_NIF_TERM enacl_crypto_ed25519_scalar_mul(ErlNifEnv *env, int argc,
+                                             ERL_NIF_TERM const argv[]);
+#endif

--- a/c_src/enacl_nif.c
+++ b/c_src/enacl_nif.c
@@ -4,6 +4,7 @@
 #include <erl_nif.h>
 
 #include "aead.h"
+#include "ed25519.h"
 #include "enacl.h"
 #include "enacl_ext.h"
 #include "generichash.h"
@@ -324,6 +325,22 @@ static ErlNifFunc nif_funcs[] = {
                                       enacl_crypto_curve25519_scalarmult),
     erl_nif_dirty_job_cpu_bound_macro("crypto_curve25519_scalarmult_base", 1,
                                       enacl_crypto_curve25519_scalarmult_base),
+    erl_nif_dirty_job_cpu_bound_macro("crypto_ed25519_scalarmult", 2,
+        enacl_crypto_ed25519_scalarmult),
+    erl_nif_dirty_job_cpu_bound_macro("crypto_ed25519_scalarmult_base", 1,
+      enacl_crypto_ed25519_scalarmult_base),
+    erl_nif_dirty_job_cpu_bound_macro("crypto_ed25519_scalarmult_noclamp", 2,
+      enacl_crypto_ed25519_scalarmult_noclamp),
+    erl_nif_dirty_job_cpu_bound_macro("crypto_ed25519_scalarmult_base_noclamp",
+        1, enacl_crypto_ed25519_scalarmult_base_noclamp),
+    {"crypto_ed25519_is_valid_point", 1, enacl_crypto_ed25519_is_valid_point},
+    {"crypto_ed25519_add", 2, enacl_crypto_ed25519_add},
+    {"crypto_ed25519_sub", 2, enacl_crypto_ed25519_sub},
+    {"crypto_ed25519_scalar_reduce", 1, enacl_crypto_ed25519_scalar_reduce},
+    {"crypto_ed25519_scalar_negate", 1, enacl_crypto_ed25519_scalar_negate},
+    {"crypto_ed25519_scalar_add", 2, enacl_crypto_ed25519_scalar_add},
+    {"crypto_ed25519_scalar_sub", 2, enacl_crypto_ed25519_scalar_sub},
+    {"crypto_ed25519_scalar_mul", 2, enacl_crypto_ed25519_scalar_mul},
 
     erl_nif_dirty_job_cpu_bound_macro("crypto_sign_ed25519_keypair", 0,
                                       enacl_crypto_sign_ed25519_keypair),

--- a/eqc_test/enacl_eqc.erl
+++ b/eqc_test/enacl_eqc.erl
@@ -1005,7 +1005,7 @@ prop_scramble_block() ->
     ?FORALL({Block, Key}, {binary(16), eqc_gen:largebinary(32)},
         is_binary(enacl_ext:scramble_block_16(Block, Key))).
 
-%% Scala multiplication
+%% Scalar multiplication
 prop_scalarmult() ->
   Bytes = 32,
   ?FORALL({S1, S2, Basepoint}, {binary(Bytes), binary(Bytes), binary(Bytes)},
@@ -1054,6 +1054,69 @@ prop_secretstream() ->
       DState = enacl:secretstream_xchacha20poly1305_init_pull(Header, Key),
       pull_messages(DState, Blocks, Msgs)
     end).
+
+%% ED25519
+gen_ed25519_point() ->
+  ?LET(Scalar, noshrink(binary(32)), return(enacl:crypto_ed25519_scalarmult_base(Scalar))).
+
+gen_ed25519_scalar() ->
+  ?LET(Bin, binary(64), return(enacl:crypto_ed25519_scalar_reduce(Bin))).
+
+prop_ed25519_add() ->
+  ?FORALL({P1, P2}, {gen_ed25519_point(), gen_ed25519_point()},
+          equals(enacl:crypto_ed25519_add(P1, P2), enacl:crypto_ed25519_add(P2, P1))
+         ).
+
+prop_ed25519_sub() ->
+  ?FORALL({P1, P2, P3}, {gen_ed25519_point(), gen_ed25519_point(), gen_ed25519_point()},
+  begin
+          equals(enacl:crypto_ed25519_sub(P1, enacl:crypto_ed25519_add(P2, P3)),
+                 enacl:crypto_ed25519_sub(enacl:crypto_ed25519_sub(P1, P2), P3))
+  end
+         ).
+
+prop_ed25519_addsub() ->
+  ?FORALL({P1, P2}, {gen_ed25519_point(), gen_ed25519_point()},
+          equals(P1, enacl:crypto_ed25519_add(enacl:crypto_ed25519_sub(P1, P2), P2))
+         ).
+
+prop_ed25519_scalarmult() ->
+  ?FORALL({S, P}, {gen_ed25519_scalar(), gen_ed25519_point()},
+          true == enacl:crypto_ed25519_is_valid_point(
+                    enacl:crypto_ed25519_scalarmult(S, P))
+         ).
+
+prop_ed25519_scalarmult_base() ->
+  ?FORALL(S, gen_ed25519_scalar(),
+          true == enacl:crypto_ed25519_is_valid_point(
+                    enacl:crypto_ed25519_scalarmult_base(S))
+         ).
+
+prop_ed25519_scalarmult_noclamp() ->
+  ?FORALL({S, P}, {binary(32), gen_ed25519_point()},
+          true == enacl:crypto_ed25519_is_valid_point(
+                    enacl:crypto_ed25519_scalarmult_noclamp(S, P))
+         ).
+
+prop_ed25519_scalarmult_base_noclamp() ->
+  ?FORALL(S, binary(32),
+          true == enacl:crypto_ed25519_is_valid_point(
+                    enacl:crypto_ed25519_scalarmult_base_noclamp(S))
+         ).
+
+prop_ed25519_scalar() ->
+  ?FORALL({S1, S2}, {gen_ed25519_scalar(), gen_ed25519_scalar()},
+          equals(
+            enacl:crypto_ed25519_scalar_add(S1, enacl:crypto_ed25519_scalar_negate(S2)),
+            enacl:crypto_ed25519_scalar_sub(S1, S2)
+           )).
+
+prop_ed25519_scalar_mul() ->
+  ?FORALL({S1, S2}, {gen_ed25519_scalar(), gen_ed25519_scalar()},
+          equals(
+            enacl:crypto_ed25519_scalar_mul(S1, S2),
+            enacl:crypto_ed25519_scalar_mul(S2, S1)
+           )).
 
 %% HELPERS
 

--- a/eqc_test/enacl_eqc.erl
+++ b/eqc_test/enacl_eqc.erl
@@ -1086,6 +1086,11 @@ prop_ed25519_scalarmult() ->
                     enacl:crypto_ed25519_scalarmult(S, P))
          ).
 
+prop_ed25519_scalarmult_1() ->
+  ?FORALL(P, gen_ed25519_point(),
+          equals(P, enacl:crypto_ed25519_scalarmult_noclamp(<<1:256/little>>, P))
+         ).
+
 prop_ed25519_scalarmult_base() ->
   ?FORALL(S, gen_ed25519_scalar(),
           true == enacl:crypto_ed25519_is_valid_point(

--- a/src/enacl.erl
+++ b/src/enacl.erl
@@ -170,7 +170,20 @@
          crypto_sign_ed25519_public_to_curve25519/1,
          crypto_sign_ed25519_secret_to_curve25519/1,
          crypto_sign_ed25519_public_size/0,
-         crypto_sign_ed25519_secret_size/0
+         crypto_sign_ed25519_secret_size/0,
+
+         crypto_ed25519_scalarmult/2,
+         crypto_ed25519_scalarmult_base/1,
+         crypto_ed25519_scalarmult_noclamp/2,
+         crypto_ed25519_scalarmult_base_noclamp/1,
+         crypto_ed25519_add/2,
+         crypto_ed25519_sub/2,
+         crypto_ed25519_is_valid_point/1,
+         crypto_ed25519_scalar_reduce/1,
+         crypto_ed25519_scalar_negate/1,
+         crypto_ed25519_scalar_add/2,
+         crypto_ed25519_scalar_sub/2,
+         crypto_ed25519_scalar_mul/2
         ]).
 
 %% Key exchange functions
@@ -1205,6 +1218,80 @@ crypto_sign_ed25519_secret_to_curve25519(SecretKey) ->
     R = enacl_nif:crypto_sign_ed25519_secret_to_curve25519(SecretKey),
     erlang:bump_reductions(?ED25519_SECRET_TO_CURVE_REDS),
     R.
+
+%% @doc crypto_ed25519_valid_point/1 checks if P is a valid point on the edwards25519 curve.
+%% @end.
+-spec crypto_ed25519_is_valid_point(P :: binary()) -> boolean().
+crypto_ed25519_is_valid_point(P) ->
+    enacl_nif:crypto_ed25519_is_valid_point(P).
+
+%% @doc crypto_ed25519_add/2 adds the point P to the point Q.
+%% @end.
+-spec crypto_ed25519_add(P :: binary(), Q :: binary()) -> binary().
+crypto_ed25519_add(P, Q) ->
+    enacl_nif:crypto_ed25519_add(P, Q).
+
+%% @doc crypto_ed25519_sub/2 subtracts the point Q from the point P.
+%% @end.
+-spec crypto_ed25519_sub(P :: binary(), Q :: binary()) -> binary().
+crypto_ed25519_sub(P, Q) ->
+    enacl_nif:crypto_ed25519_sub(P, Q).
+
+%% @doc crypto_ed25519_scalarmult/2 does a scalar multiplication between the scalar N and the point P.
+%% @end.
+-spec crypto_ed25519_scalarmult(N :: binary(), P :: binary()) -> binary().
+crypto_ed25519_scalarmult(N, P) ->
+    enacl_nif:crypto_ed25519_scalarmult(N, P).
+
+%% @doc crypto_ed25519_scalarmult_base/1 compute scalar multiplication of the scalar N and the base point.
+%% @end.
+-spec crypto_ed25519_scalarmult_base(N :: binary()) -> binary().
+crypto_ed25519_scalarmult_base(N) ->
+    enacl_nif:crypto_ed25519_scalarmult_base(N).
+
+%% @doc crypto_ed25519_scalarmult_noclamp/2 does a scalar multiplication between the scalar N and the point P.
+%% N is not clamped!
+%% @end.
+-spec crypto_ed25519_scalarmult_noclamp(N :: binary(), P :: binary()) -> binary().
+crypto_ed25519_scalarmult_noclamp(N, P) ->
+    enacl_nif:crypto_ed25519_scalarmult_noclamp(N, P).
+
+%% @doc crypto_ed25519_scalarmult_base_noclamp/1 compute scalar multiplication of the scalar N and the base point.
+%% N is not clamped!
+%% @end.
+-spec crypto_ed25519_scalarmult_base_noclamp(N :: binary()) -> binary().
+crypto_ed25519_scalarmult_base_noclamp(N) ->
+    enacl_nif:crypto_ed25519_scalarmult_base_noclamp(N).
+
+%% @doc crypto_ed25519_scalar_reduce/1 reduces the scalar s to (s mod L).
+%% @end.
+-spec crypto_ed25519_scalar_reduce(S :: binary()) -> binary().
+crypto_ed25519_scalar_reduce(S) ->
+    enacl_nif:crypto_ed25519_scalar_reduce(S).
+
+%% @doc crypto_ed25519_scalar_negate/1 returns neg so that s + neg = 0 (mod L).
+%% @end.
+-spec crypto_ed25519_scalar_negate(S :: binary()) -> binary().
+crypto_ed25519_scalar_negate(S) ->
+    enacl_nif:crypto_ed25519_scalar_negate(S).
+
+%% @doc crypto_ed25519_scalar_add/2 computes the scalar x + y (mod L).
+%% @end.
+-spec crypto_ed25519_scalar_add(X :: binary(), Y :: binary()) -> binary().
+crypto_ed25519_scalar_add(X, Y) ->
+    enacl_nif:crypto_ed25519_scalar_add(X, Y).
+
+%% @doc crypto_ed25519_scalar_sub/2 computes the scalar x - y (mod L).
+%% @end.
+-spec crypto_ed25519_scalar_sub(X :: binary(), Y :: binary()) -> binary().
+crypto_ed25519_scalar_sub(X, Y) ->
+    enacl_nif:crypto_ed25519_scalar_sub(X, Y).
+
+%% @doc crypto_ed25519_scalar_mul/2 computes the scalar x - y (mod L).
+%% @end.
+-spec crypto_ed25519_scalar_mul(X :: binary(), Y :: binary()) -> binary().
+crypto_ed25519_scalar_mul(X, Y) ->
+    enacl_nif:crypto_ed25519_scalar_mul(X, Y).
 
 -spec crypto_sign_ed25519_public_size() -> pos_integer().
 crypto_sign_ed25519_public_size() ->

--- a/src/enacl_nif.erl
+++ b/src/enacl_nif.erl
@@ -127,7 +127,20 @@
          crypto_sign_ed25519_public_to_curve25519/1,
          crypto_sign_ed25519_secret_to_curve25519/1,
          crypto_sign_ed25519_PUBLICKEYBYTES/0,
-         crypto_sign_ed25519_SECRETKEYBYTES/0
+         crypto_sign_ed25519_SECRETKEYBYTES/0,
+
+         crypto_ed25519_scalarmult/2,
+         crypto_ed25519_scalarmult_base/1,
+         crypto_ed25519_scalarmult_noclamp/2,
+         crypto_ed25519_scalarmult_base_noclamp/1,
+         crypto_ed25519_add/2,
+         crypto_ed25519_sub/2,
+         crypto_ed25519_is_valid_point/1,
+         crypto_ed25519_scalar_reduce/1,
+         crypto_ed25519_scalar_negate/1,
+         crypto_ed25519_scalar_add/2,
+         crypto_ed25519_scalar_sub/2,
+         crypto_ed25519_scalar_mul/2
         ]).
 
 %% Key exchange
@@ -365,6 +378,19 @@ crypto_sign_ed25519_keypair() -> erlang:nif_error(nif_not_loaded).
 crypto_sign_ed25519_sk_to_pk(_SecretKey) -> erlang:nif_error(nif_not_loaded).
 crypto_sign_ed25519_public_to_curve25519(_PublicKey) -> erlang:nif_error(nif_not_loaded).
 crypto_sign_ed25519_secret_to_curve25519(_SecretKey) -> erlang:nif_error(nif_not_loaded).
+crypto_ed25519_scalarmult(_S, _Base) -> erlang:nif_error(nif_not_loaded).
+crypto_ed25519_scalarmult_base(_S) -> erlang:nif_error(nif_not_loaded).
+crypto_ed25519_scalarmult_noclamp(_S, _Base) -> erlang:nif_error(nif_not_loaded).
+crypto_ed25519_scalarmult_base_noclamp(_S) -> erlang:nif_error(nif_not_loaded).
+crypto_ed25519_add(_X, _Y) -> erlang:nif_error(nif_not_loaded).
+crypto_ed25519_sub(_X, _Y) -> erlang:nif_error(nif_not_loaded).
+crypto_ed25519_is_valid_point(_P) -> erlang:nif_error(nif_not_loaded).
+crypto_ed25519_scalar_reduce(_S) -> erlang:nif_error(nif_not_loaded).
+crypto_ed25519_scalar_negate(_S) -> erlang:nif_error(nif_not_loaded).
+crypto_ed25519_scalar_add(_X, _Y) -> erlang:nif_error(nif_not_loaded).
+crypto_ed25519_scalar_sub(_X, _Y) -> erlang:nif_error(nif_not_loaded).
+crypto_ed25519_scalar_mul(_X, _Y) -> erlang:nif_error(nif_not_loaded).
+
 crypto_sign_ed25519_PUBLICKEYBYTES() -> erlang:nif_error(nif_not_loaded).
 crypto_sign_ed25519_SECRETKEYBYTES() -> erlang:nif_error(nif_not_loaded).
 


### PR DESCRIPTION
NOTE: This requires libsodium 1.0.18 or later!

This adds a low-level APIs to perform computations over the edwards25519
curve, only useful to implement custom constructions.

Exposed functions:
  crypto_ed25519_scalarmult/2,
  crypto_ed25519_scalarmult_base/1,
  crypto_ed25519_scalarmult_noclamp/2,
  crypto_ed25519_scalarmult_base_noclamp/1,
  crypto_ed25519_add/2,
  crypto_ed25519_sub/2,
  crypto_ed25519_is_valid_point/1,
  crypto_ed25519_scalar_reduce/1,
  crypto_ed25519_scalar_negate/1,
  crypto_ed25519_scalar_add/2,
  crypto_ed25519_scalar_sub/2,
  crypto_ed25519_scalar_mul/2