### PR TITLE
Add access to secretbox_easy/easy_open functions

### DIFF
--- a/c_src/enacl_nif.c
+++ b/c_src/enacl_nif.c
@@ -256,6 +256,12 @@ static ErlNifFunc nif_funcs[] = {
     {"crypto_secretbox_open_b", 3, enacl_crypto_secretbox_open},
     erl_nif_dirty_job_cpu_bound_macro("crypto_secretbox_open", 3,
                                       enacl_crypto_secretbox_open),
+    {"crypto_secretbox_easy_b", 3, enacl_crypto_secretbox_easy},
+    erl_nif_dirty_job_cpu_bound_macro("crypto_secretbox_easy", 3,
+                                      enacl_crypto_secretbox_easy),
+    {"crypto_secretbox_open_easy_b", 3, enacl_crypto_secretbox_open_easy},
+    erl_nif_dirty_job_cpu_bound_macro("crypto_secretbox_open_easy", 3,
+                                      enacl_crypto_secretbox_open_easy),
 
     {"crypto_stream_chacha20_KEYBYTES", 0,
      enacl_crypto_stream_chacha20_KEYBYTES},

--- a/c_src/secret.h
+++ b/c_src/secret.h
@@ -43,6 +43,12 @@ ERL_NIF_TERM enacl_crypto_secretbox(ErlNifEnv *env, int argc,
 ERL_NIF_TERM enacl_crypto_secretbox_open(ErlNifEnv *env, int argc,
                                          ERL_NIF_TERM const argv[]);
 
+ERL_NIF_TERM enacl_crypto_secretbox_easy(ErlNifEnv *env, int argc,
+                                         ERL_NIF_TERM const argv[]);
+
+ERL_NIF_TERM enacl_crypto_secretbox_open_easy(ErlNifEnv *env, int argc,
+                                              ERL_NIF_TERM const argv[]);
+
 ERL_NIF_TERM enacl_crypto_stream_chacha20(ErlNifEnv *env, int argc,
                                           ERL_NIF_TERM const argv[]);
 

--- a/src/enacl_nif.erl
+++ b/src/enacl_nif.erl
@@ -57,6 +57,10 @@
          crypto_secretbox_b/3,
          crypto_secretbox_open/3,
          crypto_secretbox_open_b/3,
+         crypto_secretbox_easy/3,
+         crypto_secretbox_easy_b/3,
+         crypto_secretbox_open_easy/3,
+         crypto_secretbox_open_easy_b/3,
 
          crypto_stream_chacha20_KEYBYTES/0,
          crypto_stream_chacha20_NONCEBYTES/0,
@@ -303,6 +307,10 @@ crypto_secretbox(_Msg, _Nonce, _Key) -> erlang:nif_error(nif_not_loaded).
 crypto_secretbox_b(_Msg, _Nonce, _Key) -> erlang:nif_error(nif_not_loaded).
 crypto_secretbox_open(_Msg, _Nonce, _Key) -> erlang:nif_error(nif_not_loaded).
 crypto_secretbox_open_b(_Msg, _Nonce, _Key) -> erlang:nif_error(nif_not_loaded).
+crypto_secretbox_easy(_Msg, _Nonce, _Key) -> erlang:nif_error(nif_not_loaded).
+crypto_secretbox_easy_b(_Msg, _Nonce, _Key) -> erlang:nif_error(nif_not_loaded).
+crypto_secretbox_open_easy(_Msg, _Nonce, _Key) -> erlang:nif_error(nif_not_loaded).
+crypto_secretbox_open_easy_b(_Msg, _Nonce, _Key) -> erlang:nif_error(nif_not_loaded).
 
 crypto_stream_chacha20_KEYBYTES() -> erlang:nif_error(nif_not_loaded).
 crypto_stream_chacha20_NONCEBYTES() -> erlang:nif_error(nif_not_loaded).


### PR DESCRIPTION
They are just a simplification of the secretbox API, thus it does
not provide any new functionality. But it helps mapping function
names to libsodium documentation.